### PR TITLE
Add multi-architecture support to Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,6 +60,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           # Only push for main branch and releases, not PRs
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Enable building Docker images for both linux/amd64 and linux/arm64 platforms to support Intel/AMD and ARM processors (including Apple Silicon and AWS Graviton).

